### PR TITLE
fix: vanity urls

### DIFF
--- a/docs/component/index.html
+++ b/docs/component/index.html
@@ -2,7 +2,7 @@
   <head>
     <meta
       name="go-import"
-      content="go.wasmcloud.dev/component git https://github.com/wasmCloud/go"
+      content="go.wasmcloud.dev git https://github.com/wasmCloud/go"
     />
   </head>
 </html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -2,7 +2,7 @@
   <head>
     <meta
       name="go-import"
-      content="go.wasmcloud.dev/x git https://github.com/wasmCloud/go"
+      content="go.wasmcloud.dev git https://github.com/wasmCloud/go"
     />
   </head>
 </html>

--- a/docs/provider/index.html
+++ b/docs/provider/index.html
@@ -2,7 +2,7 @@
   <head>
     <meta
       name="go-import"
-      content="go.wasmcloud.dev/provider git https://github.com/wasmCloud/go"
+      content="go.wasmcloud.dev git https://github.com/wasmCloud/go"
     />
   </head>
 </html>

--- a/docs/x/wasitel/index.html
+++ b/docs/x/wasitel/index.html
@@ -2,7 +2,7 @@
   <head>
     <meta
       name="go-import"
-      content="go.wasmcloud.dev/x git https://github.com/wasmCloud/go"
+      content="go.wasmcloud.dev git https://github.com/wasmCloud/go"
     />
   </head>
 </html>


### PR DESCRIPTION
## Feature or Problem

After some experimentation I came to the understanding that in order to get the behavior we want out of the multiple modules inside of a single repository approach, we need to change the `root-path` component of the `go-import` meta tag to `go.wasmcloud.dev` and point the `repo-url` at the consolidated repository (aka this repo).

Since `wadge` lives inside of it's own repository, we can maintain a separate entry for `go.wasmcloud.dev/wadge` and keep it pointed at wadge's (as in, nothing changes there).

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
