### PR TITLE
chore(ci): Add workflow to run go mod tidy on dependabot PRs

### DIFF
--- a/.github/workflows/dependabot-pr-go-mod-tidy.yaml
+++ b/.github/workflows/dependabot-pr-go-mod-tidy.yaml
@@ -1,0 +1,38 @@
+name: Dependabot go mod tidy
+
+on:
+  pull_request:
+    paths:
+      - '**/go.mod'
+
+permissions:
+  contents: read
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' && github.repository == 'wasmCloud/go' }}
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ github.head_ref }}
+      - uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
+        with:
+          go-version: 'stable'
+      - name: Go mod tidy
+        shell: bash
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          for mod_dir in $(find . -type f -name 'go.mod' | xargs dirname); do
+            pushd "$mod_dir"
+            go mod tidy
+            popd
+          done
+
+          git add $(git ls-files -m)
+          git commit -m "chore: go mod tidy" --signoff
+          git push


### PR DESCRIPTION
## Feature or Problem

This workflow is intended for automating `go mod tidy` after dependabot opens up a PR to update any `go.mod` files.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
