### PR TITLE
chore(ci): Only go mod tidy the changed go modules

### DIFF
--- a/.github/workflows/dependabot-pr-go-mod-tidy.yaml
+++ b/.github/workflows/dependabot-pr-go-mod-tidy.yaml
@@ -21,13 +21,25 @@ jobs:
       - uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
         with:
           go-version: 'stable'
+      - name: List changed go.mod files
+        uses: tj-actions/changed-files@bab30c2299617f6615ec02a68b9a40d10bd21366 # v45.0.5
+        id: changed_go_mod
+        with:
+          dir_names: "true"
+          files: |
+            **/go.mod
+          files_ignore: |
+            templates/**/go.mod
       - name: Go mod tidy
+        if: ${{ steps.changed_go_mod.outputs.any_changed == 'true' }}
         shell: bash
+        env:
+          CHANGED_GO_MOD_DIRS: ${{ steps.changed_go_mod.outputs.all_changed_files }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-          for mod_dir in $(find . -type f -name 'go.mod' | xargs dirname); do
+          for mod_dir in ${CHANGED_GO_MOD_DIRS}; do
             pushd "$mod_dir"
             go mod tidy
             popd


### PR DESCRIPTION
## Feature or Problem

Since we have templated `go.mod` files, we can't run `go mod tidy` across all of the available `go.mod`. Instead, this filters the list down to only the files that were changed in the PR, and ignores templates altogether.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
