### PR TITLE
chore: Use wasmcloud-automation-app for 'go mod tidy' commits

### DIFF
--- a/.github/workflows/dependabot-pr-go-mod-tidy.yaml
+++ b/.github/workflows/dependabot-pr-go-mod-tidy.yaml
@@ -41,11 +41,27 @@ jobs:
           files: |
             **/go.mod
             **/go.sum
+      - uses: actions/create-github-app-token@5d869da34e18e7287c1daad50e0b8ea0f506ce69 # v1.11.0
+        if: ${{ steps.verify_changed_files.outputs.files_changed == 'true' }}
+        id: app-token
+        with:
+          app-id: ${{ secrets.BOT_APP_ID }}
+          private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
+      - name: Get GitHub App User ID
+        if: ${{ steps.verify_changed_files.outputs.files_changed == 'true' }}
+        id: get-user-id
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          echo "user-id=$(gh api "/users/${{ steps.app-token.outputs.app-slug }}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
+      - name: Configure GitHub App as committer
+        if: ${{ steps.verify_changed_files.outputs.files_changed == 'true' }}
+        run: |
+          git config --global user.name '${{ steps.app-token.outputs.app-slug }}[bot]'
+          git config --global user.email '${{ steps.get-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com>'
       - name: Push changes
         if: ${{ steps.verify_changed_files.outputs.files_changed == 'true' }}
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add $(git ls-files -m)
+          git add .
           git commit -m "chore: go mod tidy" --signoff
           git push


### PR DESCRIPTION
## Feature or Problem

Based on an example from [`actions/create-github-app-token`](https://github.com/actions/create-github-app-token?tab=readme-ov-file#configure-git-cli-for-an-apps-bot-user)

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
