### PR TITLE
fix(docs): Switch to fully qualified links

### DIFF
--- a/examples/provider/http-server/README.md
+++ b/examples/provider/http-server/README.md
@@ -30,7 +30,7 @@ func director(r *http.Request) string {
     return "http-api"
   }
   return "http-ui"
-})
+}
 
 
 transport := wrpchttp.NewIncomingRoundTripper(wasmcloudprovider, wrpchttp.WithDirector(director))

--- a/examples/provider/keyvalue-inmemory/README.md
+++ b/examples/provider/keyvalue-inmemory/README.md
@@ -4,5 +4,5 @@ This provider implements `wrpc:keyvalue/store@0.2.0-draft`.
 
 ## Notable files
 
-- [main.go](./main.go) is a simple binary that sets up an errGroup to handle running the provider's primary requirements: executing as a standaline binary based on data received on stdin, handling RPC and connecting to a wasmCloud lattice.
-- [keyvalue.go](./keyvalue.go) implements the required functions to conform to `wasi:keyvalue/store`. If the functions as specified in the [WIT](./wit/deps/keyvalue/store.wit) are not implemented, this provider will fail to build.
+- main.go is a simple binary that sets up an errGroup to handle running the provider's primary requirements: executing as a standaline binary based on data received on stdin, handling RPC and connecting to a wasmCloud lattice.
+- keyvalue.go implements the required functions to conform to `wasi:keyvalue/store`. If the functions as specified in the `./wit` directory are not implemented, this provider will fail to build.


### PR DESCRIPTION
This updates all example docs from relative to absolute links so they can be autosynced properly with the main docs site