### PR TITLE
chore(ci): Use wash instead of wash-cli via install-action

### DIFF
--- a/.github/workflows/component-go.yaml
+++ b/.github/workflows/component-go.yaml
@@ -106,7 +106,7 @@ jobs:
           working-directory: "./examples/component/${{ matrix.example }}"
       - uses: taiki-e/install-action@acd25891978b4cdaebd139d3efef606d26513b14 # v2.47.0
         with:
-          tool: ${{ format('wash-cli@{0},wasm-tools@{1}', env.WASH_VERSION, env.WASM_TOOLS_VERSION) }}
+          tool: ${{ format('wash@{0},wasm-tools@{1}', env.WASH_VERSION, env.WASM_TOOLS_VERSION) }}
 
       - name: Go generate
         run: |

--- a/.github/workflows/component-wit.yaml
+++ b/.github/workflows/component-wit.yaml
@@ -25,7 +25,7 @@ jobs:
           echo "version is ${version}"
     - uses: taiki-e/install-action@acd25891978b4cdaebd139d3efef606d26513b14
       with:
-        tool: wash-cli@0.36.1
+        tool: wash@0.37.0
     - name: Generate and set config
       shell: bash
       env:

--- a/.github/workflows/component-wit.yaml
+++ b/.github/workflows/component-wit.yaml
@@ -15,7 +15,7 @@ jobs:
       contents: write # for softprops/action-gh-release
       packages: write # for publishing the wit to ghcr.io
     steps:
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Extract tag context
       id: ctx
       run: |
@@ -23,7 +23,7 @@ jobs:
           echo "version=${version}" >> "$GITHUB_OUTPUT"
           echo "tarball=wit-${version}.tar.gz" >> "$GITHUB_OUTPUT"
           echo "version is ${version}"
-    - uses: taiki-e/install-action@acd25891978b4cdaebd139d3efef606d26513b14
+    - uses: taiki-e/install-action@acd25891978b4cdaebd139d3efef606d26513b14 # v2.47.0
       with:
         tool: wash@0.37.0
     - name: Generate and set config
@@ -52,7 +52,7 @@ jobs:
       run: |
         tar -cvzf ${{ steps.ctx.outputs.tarball }} -C ./component wit
     - name: Release
-      uses: softprops/action-gh-release@7b4da11513bf3f43f9999e90eabced41ab8bb048
+      uses: softprops/action-gh-release@7b4da11513bf3f43f9999e90eabced41ab8bb048 # v2.2.0
       with:
         files: ${{ steps.ctx.outputs.tarball }}
         make_latest: "false"

--- a/.github/workflows/templates-go.yaml
+++ b/.github/workflows/templates-go.yaml
@@ -40,7 +40,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: taiki-e/install-action@acd25891978b4cdaebd139d3efef606d26513b14 # v2.47.0
         with:
-          tool: ${{ format('wash-cli@{0},wasm-tools@{1},wrpc@{2}', env.WASH_VERSION, env.WASM_TOOLS_VERSION, env.WRPC_VERSION) }}
+          tool: ${{ format('wash@{0},wasm-tools@{1},wrpc@{2}', env.WASH_VERSION, env.WASM_TOOLS_VERSION, env.WRPC_VERSION) }}
       - uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
         with:
           go-version-file: "templates/provider/${{ matrix.template-name }}/go.mod"
@@ -78,7 +78,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: taiki-e/install-action@acd25891978b4cdaebd139d3efef606d26513b14 # v2.47.0
         with:
-          tool: ${{ format('wash-cli@{0},wasm-tools@{1}', env.WASH_VERSION, env.WASM_TOOLS_VERSION) }}
+          tool: ${{ format('wash@{0},wasm-tools@{1}', env.WASH_VERSION, env.WASM_TOOLS_VERSION) }}
       - uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
         with:
           go-version-file: "templates/component/${{ matrix.template-name }}/go.mod"


### PR DESCRIPTION
## Feature or Problem

Since [`taiki-e/install-action@v2.47.0`](https://github.com/taiki-e/install-action/releases/tag/v2.47.0) now includes `wash` as built-in, it would make sense to switch to that instead of falling back to `cargo binstall` for `wash-cli` as we have been as the built-in option will be faster to install.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
