### PR TITLE
fix(examples): Make sure READMEs link to themselves

### DIFF
--- a/examples/component/http-client/README.md
+++ b/examples/component/http-client/README.md
@@ -1,6 +1,7 @@
 # Go HTTP Client
 
-This repository contains a WebAssembly Component compiled using [TinyGo][tinygo], which:
+[This example](https://github.com/wasmCloud/go/tree/main/examples/component/http-client) is a
+WebAssembly Component compiled using [TinyGo][tinygo], which:
 
 - Implements a [`wasi:http`][wasi-http]-compliant HTTP handler
 - Uses the [`httpserver` provider][httpserver-provider] to serve requests

--- a/examples/component/http-password-checker/README.md
+++ b/examples/component/http-password-checker/README.md
@@ -1,6 +1,7 @@
 # TinyGo HTTP Password Checker
 
-This repository contains a WebAssembly Component written in [TinyGo][tinygo], which:
+[This example](https://github.com/wasmCloud/go/tree/main/examples/component/http-password-checker)
+is a WebAssembly Component written in [TinyGo][tinygo], which:
 
 - Implements a [`wasi:http`][wasi-http]-compliant HTTP handler
 - Uses the [`httpserver` provider][httpserver-provider] to serve requests

--- a/examples/component/http-server/README.md
+++ b/examples/component/http-server/README.md
@@ -1,6 +1,7 @@
-# Go HTTP Password Checker
+# Go HTTP Server
 
-This repository contains a WebAssembly Component compiled using [TinyGo][tinygo], which:
+[This example](https://github.com/wasmCloud/go/tree/main/examples/component/http-server) is a
+WebAssembly Component compiled using [TinyGo][tinygo], which:
 
 - Implements a [`wasi:http`][wasi-http]-compliant HTTP handler
 - Uses the [`httpserver` provider][httpserver-provider] to serve requests

--- a/examples/component/invoke/README.md
+++ b/examples/component/invoke/README.md
@@ -1,7 +1,8 @@
 # Custom WIT example
 
-This example shows how to combine the wasmCloud Component SDK with your custom interfaces. You can
-find the custom interface in `wit/world.wit`. It should look something like this:
+[This example](https://github.com/wasmCloud/go/tree/main/examples/component/invoke) shows how to
+combine the wasmCloud Component SDK with your custom interfaces. You can find the custom interface
+in `wit/world.wit`. It should look something like this:
 
 ```wit
 interface invoker {

--- a/examples/component/sqldb-postgres-query/README.md
+++ b/examples/component/sqldb-postgres-query/README.md
@@ -1,6 +1,7 @@
 # 🐘 SQLDB Postgres Example
 
-This folder contains a WebAssembly component that makes use of:
+[This example](https://github.com/wasmCloud/go/tree/main/examples/component/sqldb-postgres-query) is
+a WebAssembly component that makes use of:
 
 - The [`wasmcloud:postgres` WIT contract](https://github.com/wasmCloud/wasmCloud/tree/main/wit/postgres)
 - The

--- a/examples/provider/http-server/README.md
+++ b/examples/provider/http-server/README.md
@@ -1,6 +1,7 @@
 # http-server
 
-This example demonstrates how to forward requests to components exporting `wasi:http/incoming-handler`.
+[This example](https://github.com/wasmCloud/go/tree/main/examples/provider/http-server) demonstrates
+how to forward requests to components exporting `wasi:http/incoming-handler`.
 
 It starts a http server listening on port 8080 containing 2 routes:
 

--- a/examples/provider/keyvalue-inmemory/README.md
+++ b/examples/provider/keyvalue-inmemory/README.md
@@ -1,6 +1,7 @@
 # Keyvalue inmemory golang provider
 
-This provider implements `wrpc:keyvalue/store@0.2.0-draft`.
+[This provider example](https://github.com/wasmCloud/go/tree/main/examples/provider/keyvalue-inmemory)
+is implements `wrpc:keyvalue/store@0.2.0-draft`.
 
 ## Notable files
 


### PR DESCRIPTION
This makes it so it is easy for the copied docs to link back to the repo. There are probably other things we can do in the future to make this better, but should be a good start