### PR TITLE
chore(examples): Expand provider example readmes

### DIFF
--- a/examples/provider/http-server/README.md
+++ b/examples/provider/http-server/README.md
@@ -1,17 +1,98 @@
-# http-server
+# wasmCloud HTTP Server Provider
 
-[This example](https://github.com/wasmCloud/go/tree/main/examples/provider/http-server) demonstrates
-how to forward requests to components exporting `wasi:http/incoming-handler`.
+This [capability provider example](https://github.com/wasmCloud/go/tree/main/examples/provider/http-server) imports the `wasi:http/incoming-handler` interface and demonstrates how to forward HTTP requests to components that export the same interface, enabling components to accept incoming HTTP(s) requests.
 
-It starts a http server listening on port 8080 containing 2 routes:
+The provider starts an HTTP server listening on port 8080 with two routes:
 
 - `/proxy`: Forwards the request to the component `http-component`
-- `/`: Serve the request directly from the provider
+- `/`: Serves the request directly from the provider
 
-# Internals
+## 👟 Run the provider
 
-Proxying uses a custom `http.RoundTripper` implementation that forwards requests to the component.
-In this example we forward to a single target ( `http-http_component` ).
+Clone the [wasmCloud/go repository](https://github.com/wasmcloud/go): 
+
+```shell
+git clone https://github.com/wasmCloud/go.git
+```
+
+Change directory to `examples/provider/http-server`:
+
+```shell
+cd examples/provider/http-server
+```
+
+In addition to the standard elements of a Go project, the example directory includes the following files and directories:
+
+- `/bindings`: Directory for Go bindings of [interfaces](https://wasmcloud.com/docs/concepts/interfaces)
+- `/wit`: Directory for WebAssembly Interface Type (WIT) packages that define interfaces
+- `wadm.yaml`: Declarative application manifest
+- `wasmcloud.toml`: Configuration file for a wasmCloud application
+
+### Build the provider
+
+Build the provider:
+
+```shell
+wash build
+```
+
+The build process will generate a `.par.gz` archive file in a new `/build` directory.
+
+### Start a wasmCloud environment
+
+Start a local wasmCloud environment (using the `-d`/`--detached` flag to run in the background):
+
+```shell
+wash up -d
+```
+
+### Deploy the application
+
+The application manifest (`wadm.yaml`) for this example defines an application consisting of the locally built provider at `./build/http-server.par.gz` and an OCI image for an HTTP "Hello World" component.
+
+Deploy the manifest:
+
+```shell
+wash app deploy wadm.yaml
+```
+
+To ensure that the application has reached `Deployed` status, you can use `wash app list`:
+
+```shell
+wash app list
+```
+
+### Send a request
+
+Send a request to the proxy route:
+
+```shell
+curl localhost:8080/proxy
+```
+
+Send a request to the index route:
+
+```shell
+curl localhost:8080
+```
+
+### Clean up
+
+You can delete an application from your wasmCloud environment by referring either to its application name (`http`) or the original application manifest:
+
+```shell
+wash app delete wadm.yaml
+```
+
+Stop your local wasmCloud environment:
+
+```shell
+wash down
+```
+
+## 🩻 Internals
+
+Proxying uses a custom `http.RoundTripper` implementation that forwards requests to the component. This example forwards to a single target (`http-http_component`).
 
 ```go
 transport := wrpchttp.NewIncomingRoundTripper(wasmcloudprovider, wrpchttp.WithSingleTarget("http-http_component"))
@@ -47,3 +128,9 @@ wasiIncomingClient.Get("http://api/users")
 wasiIncomingClient.Get("http://ui/index.html")
 wasiIncomingClient.Get("http://anyothername/index.html")
 ```
+
+## 📖 Further reading
+
+For an introduction to capability providers, see the [Providers Overview](https://wasmcloud.com/docs/concepts/providers) in the wasmCloud documentation.
+
+For more on building providers, see the [Provider Developer Guide](https://wasmcloud.com/docs/developer/providers/) in the wasmCloud documentation. 

--- a/examples/provider/http-server/README.md
+++ b/examples/provider/http-server/README.md
@@ -1,4 +1,4 @@
-# wasmCloud HTTP Server Provider
+# HTTP Server Provider
 
 This [capability provider example](https://github.com/wasmCloud/go/tree/main/examples/provider/http-server) imports the `wasi:http/incoming-handler` interface and demonstrates how to forward HTTP requests to components that export the same interface, enabling components to accept incoming HTTP(s) requests.
 
@@ -23,10 +23,10 @@ cd examples/provider/http-server
 
 In addition to the standard elements of a Go project, the example directory includes the following files and directories:
 
-- `/bindings`: Directory for Go bindings of [interfaces](https://wasmcloud.com/docs/concepts/interfaces)
-- `/wit`: Directory for WebAssembly Interface Type (WIT) packages that define interfaces
-- `wadm.yaml`: Declarative application manifest
-- `wasmcloud.toml`: Configuration file for a wasmCloud application
+- `/bindings`: An auto-generated directory for Go bindings of [interfaces](https://wasmcloud.com/docs/concepts/interfaces). Users typically will not need to interact directly with the contents of this directory.
+- `/wit`: Directory for WebAssembly Interface Type (WIT) packages that define interfaces.
+- `wadm.yaml`: Declarative application manifest.
+- `wasmcloud.toml`: Configuration file for a wasmCloud application.
 
 ### Build the provider
 

--- a/examples/provider/keyvalue-inmemory/README.md
+++ b/examples/provider/keyvalue-inmemory/README.md
@@ -18,11 +18,11 @@ cd examples/provider/keyvalue-inmemory
 
 In addition to the standard elements of a Go project, the example directory includes the following files and directories:
 
-- `/bindings`: Directory for Go bindings of [interfaces](https://wasmcloud.com/docs/concepts/interfaces)
-- `/wit`: Directory for WebAssembly Interface Type (WIT) packages that define interfaces
-- `wasmcloud.toml`: Configuration file for a wasmCloud application
+- `/bindings`: An auto-generated directory for Go bindings of [interfaces](https://wasmcloud.com/docs/concepts/interfaces). Users typically will not need to interact directly with the contents of this directory.
+- `/wit`: Directory for WebAssembly Interface Type (WIT) packages that define interfaces.
+- `wasmcloud.toml`: Configuration file for a wasmCloud application.
 
-The example includes a shell script to simplify running the Go project:
+The example includes a shell script that simulates what the host does to run the provider, enabling you to test the provider without running a host.
 
 ```shell
 ./run.sh
@@ -37,22 +37,13 @@ echo $host_data | base64 | go run ./
 
 ## 🛠️ Build the provider
 
-The example includes a shell script to simplify the build process:
+Build the provider:
 
 ```shell
-./build.sh
+wash build
 ```
 
-You can also perform each step manually:
-
-```shell
-go generate ./...
-go build ./
-wash par create --vendor wasmcloud --name "KeyValue Go" --binary ./keyvalue-inmemory --compress
-rm keyvalue-inmemory
-```
-
-The build process will generate a `.par.gz` archive file.
+The build process will generate a `.par.gz` archive file in a new `/build` directory.
 
 ## 🩻 Internals
 

--- a/examples/provider/keyvalue-inmemory/README.md
+++ b/examples/provider/keyvalue-inmemory/README.md
@@ -1,9 +1,66 @@
-# Keyvalue inmemory golang provider
+# In-Memory Key-Value Storage Provider
 
-[This provider example](https://github.com/wasmCloud/go/tree/main/examples/provider/keyvalue-inmemory)
-is implements `wrpc:keyvalue/store@0.2.0-draft`.
+[This capability provider example](https://github.com/wasmCloud/go/tree/main/examples/provider/keyvalue-inmemory) implements `wrpc:keyvalue/store@0.2.0-draft` to provide key-value functionality (backed in-memory) for components that **import** the same interface. 
 
-## Notable files
+## 👟 Run the Go project
 
-- main.go is a simple binary that sets up an errGroup to handle running the provider's primary requirements: executing as a standaline binary based on data received on stdin, handling RPC and connecting to a wasmCloud lattice.
-- keyvalue.go implements the required functions to conform to `wasi:keyvalue/store`. If the functions as specified in the `./wit` directory are not implemented, this provider will fail to build.
+Clone the [wasmCloud/go repository](https://github.com/wasmcloud/go): 
+
+```shell
+git clone https://github.com/wasmCloud/go.git
+```
+
+Change directory to `examples/provider/keyvalue-inmemory`:
+
+```shell
+cd examples/provider/keyvalue-inmemory
+```
+
+In addition to the standard elements of a Go project, the example directory includes the following files and directories:
+
+- `/bindings`: Directory for Go bindings of [interfaces](https://wasmcloud.com/docs/concepts/interfaces)
+- `/wit`: Directory for WebAssembly Interface Type (WIT) packages that define interfaces
+- `wasmcloud.toml`: Configuration file for a wasmCloud application
+
+The example includes a shell script to simplify running the Go project:
+
+```shell
+./run.sh
+```
+
+You can also perform each step manually:
+
+```shell
+host_data='{"lattice_rpc_url": "0.0.0.0:4222", "lattice_rpc_prefix": "default", "provider_key": "keyvalue-inmemory", "link_name": "default","log_level": "debug"}' 
+echo $host_data | base64 | go run ./
+```
+
+## 🛠️ Build the provider
+
+The example includes a shell script to simplify the build process:
+
+```shell
+./build.sh
+```
+
+You can also perform each step manually:
+
+```shell
+go generate ./...
+go build ./
+wash par create --vendor wasmcloud --name "KeyValue Go" --binary ./keyvalue-inmemory --compress
+rm keyvalue-inmemory
+```
+
+The build process will generate a `.par.gz` archive file.
+
+## 🩻 Internals
+
+- `main.go` is a simple binary that sets up an errGroup to handle running the provider's primary requirements: executing as a standalone binary based on data received on stdin, handling RPC, and connecting to a wasmCloud lattice.
+- `keyvalue.go` implements the required functions to conform to `wasi:keyvalue/store`. If the functions as specified in the `./wit` directory are not implemented, this provider will fail to build.
+
+## 📖 Further reading
+
+For an introduction to capability providers, see the [Providers Overview](https://wasmcloud.com/docs/concepts/providers) in the wasmCloud documentation.
+
+For more on building providers, see the [Provider Developer Guide](https://wasmcloud.com/docs/developer/providers/) in the wasmCloud documentation. 

--- a/examples/provider/keyvalue-inmemory/build.sh
+++ b/examples/provider/keyvalue-inmemory/build.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-# Build the Go binary and package it into a par file
-# This is designed to be run from the root of the project
-go generate ./...
-go build ./
-wash par create --vendor wasmcloud --name "KeyValue Go" --binary ./keyvalue-inmemory --compress
-rm keyvalue-inmemory


### PR DESCRIPTION
Expands and works toward standardizing the readmes for Go provider examples.