### PR TITLE
chore(examples): small consistency and correctness fixes to http-keyvalue-crud

### DIFF
--- a/examples/component/http-keyvalue-crud/README.md
+++ b/examples/component/http-keyvalue-crud/README.md
@@ -26,9 +26,9 @@ cd examples/component/http-keyvalue-crud
 
 In addition to the standard elements of a Go project, the example directory includes the following files and directories:
 
-- `build/`: Target directory for compiled `.wasm` binaries
-- `gen/`: Target directory for Go bindings of [interfaces](https://wasmcloud.com/docs/concepts/interfaces)
-- `wit/`: Directory for WebAssembly Interface Type (WIT) packages that define interfaces
+- `/build`: Target directory for compiled `.wasm` binaries
+- `/gen`: Target directory for Go bindings of [interfaces](https://wasmcloud.com/docs/concepts/interfaces)
+- `/wit`: Directory for WebAssembly Interface Type (WIT) packages that define interfaces
 - `bindings.wadge.go`: Automatically generated test bindings
 - `wadm.yaml`: Declarative application manifest
 - `wasmcloud.lock`: Automatically generated lockfile for WIT packages

--- a/examples/component/http-keyvalue-crud/main.go
+++ b/examples/component/http-keyvalue-crud/main.go
@@ -1,4 +1,4 @@
-//go:generate go run go.bytecodealliance.org/cmd/wit-bindgen-go generate --world hello --out gen ./wit
+//go:generate go run go.bytecodealliance.org/cmd/wit-bindgen-go generate --world component --out gen ./wit
 package main
 
 import (
@@ -167,5 +167,5 @@ func errResponseJSON(w http.ResponseWriter, code int, message string) {
 }
 
 // Since we don't run this program like a CLI, the `main` function is empty. Instead,
-// we call the `handleRequest` function when an HTTP request is received.
+// we call handler functions when an HTTP request is received.
 func main() {}


### PR DESCRIPTION
A few small consistency and correctness updates to the http-keyvalue-crud example in conjunction with a blog post about it.