### PR TITLE
Fix provider lattice connection to use credentials if host provides

### DIFF
--- a/provider/provider.go
+++ b/provider/provider.go
@@ -153,7 +153,13 @@ func NewWithHostDataSource(source io.Reader, options ...ProviderHandler) (*Wasmc
 	}
 
 	// Connect to NATS
-	nc, err := nats.Connect(hostData.LatticeRPCURL)
+	var nc *nats.Conn
+	var natsOpts []nats.Option
+	if hostData.LatticeRPCUserSeed != "" && hostData.LatticeRPCUserJWT != "" {
+		natsOpts = append(natsOpts, nats.UserJWTAndSeed(hostData.LatticeRPCUserJWT, hostData.LatticeRPCUserSeed))
+		logger.Debug("connecting to nats with userJWTAndSeed")
+	}
+	nc, err = nats.Connect(hostData.LatticeRPCURL, natsOpts...)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Provider now initiates nats lattice connection in-case host provides jwt and seed, if not default to only connecting using nats-url.
## Feature or Problem
Provider fails with: Failed to connect to NATS: authorization violation: nats: authorization violation
when using provider and lattice requires credentials authentication

## Related Issues
#176
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
next release
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
Shouldn't be any blast radius as you're not allowed to start a wasmcloud host without a nats connection.
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
Tested it and it's working
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
N/A
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
N/A
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
Attached a custom provider to a component which before the change, had no nats credentials towards the lattice which failed.
Tried with this change, and it now works as expected.
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
