### PR TITLE
chore(examples): update addresses to 0.0.0.0

### DIFF
--- a/examples/component/http-keyvalue-crud/wadm.yaml
+++ b/examples/component/http-keyvalue-crud/wadm.yaml
@@ -32,7 +32,7 @@ spec:
           config:
           - name: wasi-http-config
             properties:
-              address: 127.0.0.1:8000
+              address: 0.0.0.0:8000
         target:
           name: crud
   - name: crud

--- a/x/wasmbus/wadm/testdata/duplicate_links.yaml
+++ b/x/wasmbus/wadm/testdata/duplicate_links.yaml
@@ -36,7 +36,7 @@ spec:
             source_config:
               - name: default-http
                 properties:
-                  address: 127.0.0.1:8080
+                  address: 0.0.0.0:8080
         - type: link
           properties:
             target: http-component-two
@@ -46,4 +46,4 @@ spec:
             source_config:
               - name: default-http-two
                 properties:
-                  address: 127.0.0.1:8081
+                  address: 0.0.0.0:8081

--- a/x/wasmbus/wadm/testdata/valid/duplicate_links.yaml
+++ b/x/wasmbus/wadm/testdata/valid/duplicate_links.yaml
@@ -36,7 +36,7 @@ spec:
             source_config:
               - name: default-http
                 properties:
-                  address: 127.0.0.1:8080
+                  address: 0.0.0.0:8080
         - type: link
           properties:
             target: http-component-two
@@ -46,4 +46,4 @@ spec:
             source_config:
               - name: default-http-two
                 properties:
-                  address: 127.0.0.1:8081
+                  address: 0.0.0.0:8081


### PR DESCRIPTION
Standardize HTTP provider address as 0.0.0.0 across `wadm.yaml` files to reduce friction when running with wasmCloud operator.
