### PR TITLE
feat: wasmbus Event Router

### DIFF
--- a/x/wasmbus/events/router.go
+++ b/x/wasmbus/events/router.go
@@ -1,0 +1,59 @@
+package events
+
+import (
+	"context"
+	"sync"
+
+	"go.wasmcloud.dev/x/wasmbus"
+)
+
+// Router is a multiplexer for events. It routes events to the appropriate handlers based on the event type.
+// Use the `AddRoute` and `RemoveRoute` methods to add and remove routes, these are safe for concurrent use.
+// Safe to be created manually or via the `NewEventRouter` function.
+type Router struct {
+	routes sync.Map
+}
+
+var _ EventHandler = (*Router)(nil)
+
+// NewEventRouter creates a new EventRouter.
+// It demultiplexes events to the appropriate handlers based on the event type, using a single event bus subscription.
+func NewEventRouter() *Router {
+	return &Router{}
+}
+
+// Route creates a new EventRouteHandler for the given event type.
+func Route[T any](callback func(context.Context, T)) EventHandler {
+	return DiscardErrorsHandler(func(ctx context.Context, ev Event) {
+		typedEvent, ok := ev.BusEvent.(T)
+		if !ok {
+			return
+		}
+
+		callback(ctx, typedEvent)
+	})
+}
+
+// AddRoute adds a new route to the event router.
+func (r *Router) AddRoute(identifier string, route EventHandler) {
+	r.routes.LoadOrStore(identifier, route)
+}
+
+// RemoveRoute removes a route from the event router.
+func (r *Router) RemoveRoute(identifier string) {
+	r.routes.Delete(identifier)
+}
+
+// HandleEvent implements the EventHandler interface
+func (r *Router) HandleEvent(ctx context.Context, event Event) {
+	r.routes.Range(func(key any, value any) bool {
+		handler := value.(EventHandler)
+		handler.HandleEvent(ctx, event)
+		return true
+	})
+}
+
+// HandleError implements the EventHandler interface
+func (r *Router) HandleError(context.Context, *wasmbus.Message, error) {
+	// serialization errors are discarded
+}

--- a/x/wasmbus/events/router_test.go
+++ b/x/wasmbus/events/router_test.go
@@ -1,0 +1,115 @@
+package events
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"go.wasmcloud.dev/x/wasmbus"
+	"go.wasmcloud.dev/x/wasmbus/wasmbustest"
+)
+
+func TestRouter(t *testing.T) {
+	defer wasmbustest.MustStartNats(t)()
+	nc, err := wasmbus.NatsConnect(wasmbus.NatsDefaultURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer nc.Close()
+
+	bus := wasmbus.NewNatsBus(nc)
+
+	t.Run("valid route", func(t *testing.T) {
+		router := NewEventRouter()
+
+		evChan := make(chan *HostHeartbeat, 1)
+		sub, err := Subscribe(
+			bus,
+			"default",
+			wasmbus.PatternAll,
+			wasmbus.NoBackLog,
+			router)
+		if err != nil {
+			t.Fatal(err)
+		}
+		router.AddRoute("heartbeat", Route(func(ctx context.Context, ev *HostHeartbeat) {
+			evChan <- ev
+		}))
+
+		// Publish an event
+		hbEv, err := EncodeEvent("com.wasmcloud.lattice.host_heartbeat", "test", "test", HostHeartbeat{
+			HostId: "my-host-name",
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		evMsg, err := wasmbus.Encode("wasmbus.evt.default.host_heartbeat", &hbEv.CloudEvent)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if err := bus.Publish(evMsg); err != nil {
+			t.Fatal(err)
+		}
+
+		var ev *HostHeartbeat
+		select {
+		case ev = <-evChan:
+			break
+		case <-time.After(1 * time.Second):
+			t.Fatal("expected event, got none")
+		}
+
+		if want, got := "my-host-name", ev.HostId; want != got {
+			t.Fatalf("want %q, got %q", want, got)
+		}
+
+		if err := sub.Drain(); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("invalid route", func(t *testing.T) {
+		router := NewEventRouter()
+
+		evChan := make(chan *HostStopped, 1)
+		sub, err := Subscribe(
+			bus,
+			"default",
+			wasmbus.PatternAll,
+			wasmbus.NoBackLog,
+			router)
+		if err != nil {
+			t.Fatal(err)
+		}
+		router.AddRoute("host-stop", Route(func(ctx context.Context, ev *HostStopped) {
+			evChan <- ev
+		}))
+
+		// Publish an event
+		hbEv, err := EncodeEvent("com.wasmcloud.lattice.host_heartbeat", "test", "test", HostHeartbeat{
+			HostId: "my-host-name",
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		evMsg, err := wasmbus.Encode("wasmbus.evt.default.host_heartbeat", &hbEv.CloudEvent)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if err := bus.Publish(evMsg); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := sub.Drain(); err != nil {
+			t.Fatal(err)
+		}
+
+		select {
+		case <-evChan:
+			t.Fatal("expected no event, got one")
+		default:
+		}
+	})
+}


### PR DESCRIPTION
Implements an multiplexer for Events, allowing many handlers to receive fully typed events and share a single nats connection/subscription.
