### PR TITLE
Fix connection timeout and GET method

### DIFF
--- a/component/net/wasihttp/roundtripper.go
+++ b/component/net/wasihttp/roundtripper.go
@@ -35,7 +35,16 @@ var DefaultClient = &http.Client{Transport: DefaultTransport}
 
 func (r *Transport) requestOptions() types.RequestOptions {
 	options := types.NewRequestOptions()
-	options.SetConnectTimeout(cm.Some(monotonicclock.Duration(r.ConnectTimeout)))
+	if r.ConnectTimeout > 0 {
+		// Go’s time.Duration is a nanosecond count, and WASI’s monotonicclock.Duration is also a u64 of nanoseconds
+		options.SetConnectTimeout(
+			cm.Some(monotonicclock.Duration(r.ConnectTimeout)),
+		)
+	} else {
+		options.SetConnectTimeout(
+			cm.None[monotonicclock.Duration](),
+		)
+	}
 	return options
 }
 

--- a/component/net/wasihttp/roundtripper.go
+++ b/component/net/wasihttp/roundtripper.go
@@ -93,7 +93,7 @@ func (r *Transport) RoundTrip(incomingRequest *http.Request) (*http.Response, er
 		outTrailers := types.NewFields()
 		if err := HTTPtoWASIHeader(incomingRequest.Trailer, outTrailers); err != nil {
 			return nil, err
-		}	
+		}
 		maybeTrailers = cm.Some(outTrailers)
 	}
 
@@ -110,7 +110,7 @@ func (r *Transport) RoundTrip(incomingRequest *http.Request) (*http.Response, er
 		if err := adaptedBody.Close(); err != nil {
 			return nil, fmt.Errorf("failed to close body: %v", err)
 		}
-	} 
+	}
 
 	// From `outgoing-body` documentation:
 	// Finalize an outgoing body, optionally providing trailers. This must be

--- a/component/net/wasihttp/roundtripper.go
+++ b/component/net/wasihttp/roundtripper.go
@@ -77,27 +77,32 @@ func (r *Transport) RoundTrip(incomingRequest *http.Request) (*http.Response, er
 		outRequest.SetScheme(cm.Some(types.SchemeOther(incomingRequest.URL.Scheme)))
 	}
 
-	var adaptedBody io.WriteCloser
-	var body *types.OutgoingBody
-	if incomingRequest.Body != nil {
-		bodyRes := outRequest.Body()
-		if bodyRes.IsErr() {
-			return nil, fmt.Errorf("failed to acquire resource handle to request body: %s", bodyRes.Err())
-		}
-		body = bodyRes.OK()
-		adaptedBody, err = NewOutgoingBody(body)
-		if err != nil {
-			return nil, fmt.Errorf("failed to adapt body: %s", err)
-		}
+	bodyRes := outRequest.Body()
+	if bodyRes.IsErr() {
+		return nil, fmt.Errorf("failed to acquire resource handle to request body: %s", bodyRes.Err())
 	}
+	body := bodyRes.OK()
 
 	handleResp := outgoinghandler.Handle(outRequest, cm.Some(r.requestOptions()))
 	if handleResp.Err() != nil {
 		return nil, fmt.Errorf("%v", handleResp.Err())
 	}
 
+	maybeTrailers := cm.None[types.Fields]()
+	if len(incomingRequest.Trailer) > 0 {
+		outTrailers := types.NewFields()
+		if err := HTTPtoWASIHeader(incomingRequest.Trailer, outTrailers); err != nil {
+			return nil, err
+		}	
+		maybeTrailers = cm.Some(outTrailers)
+	}
+
 	// NOTE(lxf): If request includes a body, copy it to the adapted wasi body
-	if body != nil {
+	if incomingRequest.Body != nil {
+		adaptedBody, err := NewOutgoingBody(body)
+		if err != nil {
+			return nil, fmt.Errorf("failed to adapt body: %s", err)
+		}
 		if _, err := io.Copy(adaptedBody, incomingRequest.Body); err != nil {
 			return nil, fmt.Errorf("failed to copy body: %v", err)
 		}
@@ -105,21 +110,14 @@ func (r *Transport) RoundTrip(incomingRequest *http.Request) (*http.Response, er
 		if err := adaptedBody.Close(); err != nil {
 			return nil, fmt.Errorf("failed to close body: %v", err)
 		}
+	} 
 
-		outTrailers := types.NewFields()
-		if err := HTTPtoWASIHeader(incomingRequest.Trailer, outTrailers); err != nil {
-			return nil, err
-		}
-
-		maybeTrailers := cm.None[types.Fields]()
-		if len(incomingRequest.Trailer) > 0 {
-			maybeTrailers = cm.Some(outTrailers)
-		}
-
-		outFinish := types.OutgoingBodyFinish(*body, maybeTrailers)
-		if outFinish.IsErr() {
-			return nil, fmt.Errorf("failed to finish body: %v", outFinish.Err())
-		}
+	// From `outgoing-body` documentation:
+	// Finalize an outgoing body, optionally providing trailers. This must be
+    // called to signal that the response is complete.
+	outFinish := types.OutgoingBodyFinish(*body, maybeTrailers)
+	if outFinish.IsErr() {
+		return nil, fmt.Errorf("failed to finish body: %v", outFinish.Err())
 	}
 
 	// NOTE(lxf): Request is fully sent. Processing response.

--- a/component/net/wasihttp/roundtripper.go
+++ b/component/net/wasihttp/roundtripper.go
@@ -114,7 +114,7 @@ func (r *Transport) RoundTrip(incomingRequest *http.Request) (*http.Response, er
 
 	// From `outgoing-body` documentation:
 	// Finalize an outgoing body, optionally providing trailers. This must be
-    // called to signal that the response is complete.
+	// called to signal that the response is complete.
 	outFinish := types.OutgoingBodyFinish(*body, maybeTrailers)
 	if outFinish.IsErr() {
 		return nil, fmt.Errorf("failed to finish body: %v", outFinish.Err())


### PR DESCRIPTION
Thanks for maintaining this library. I am using it as a `wasi-http` wrapper, with embedded `wasmtime`, so not directly with`wasmcloud`. If this is out of scope for this library feel free to close the PR.

## Feature or Problem
I've tried `wasihttp` package but encountered two problems:
* Getting `connection-timeout`: Initializing the client as in `examples/component/http-client/main.go`: 
```go
var (
	wasiTransport = &wasihttp.Transport{}
	httpClient    = &http.Client{Transport: wasiTransport}
)
```
was calling `set-connect-timeout` with `Some(0)`, and thus I was always getting `Err(connection-timeout)`.

* Attempting to use a method without body, e.g. GET was failing (no request showed up in Wireshark) because `outgoing-body.finish` was not called.

## Related Issues
Slightly related https://github.com/wasmCloud/go/issues/243 - I did not encounter any issues with `wasm-tools` 1.229.0.

## Release Information
wasm-tools 1.229.0
wasmtime 31.0.0
tinygo version 0.37.0 linux/amd64 (using go version go1.24.2 and LLVM version 19.1.7)
wit-bindgen-go-cli 0.6.2


## Testing

### Manual Verification
I've tested GET and POST request.