### PR TITLE
fix(net/wasihttp): exponential backoff polling after yield

### DIFF
--- a/component/net/wasihttp/roundtripper.go
+++ b/component/net/wasihttp/roundtripper.go
@@ -117,7 +117,7 @@ func (r *Transport) RoundTrip(incomingRequest *http.Request) (*http.Response, er
 	futureResponse := handleResp.OK()
 
 	// wait until resp is returned
-	poll.PollWithBackoff(futureResponse.Subscribe())
+	poll.Resolve(futureResponse.Subscribe())
 
 	pollableOption := futureResponse.Get()
 	if pollableOption.None() {

--- a/component/net/wasihttp/streams.go
+++ b/component/net/wasihttp/streams.go
@@ -88,7 +88,7 @@ func (r *inputStreamReader) parseTrailers() {
 
 func (r *inputStreamReader) Read(p []byte) (n int, err error) {
 	pollable := r.stream.Subscribe()
-	poll.PollWithBackoff(pollable)
+	poll.Resolve(pollable)
 	pollable.ResourceDrop()
 
 	readResult := r.stream.Read(uint64(len(p)))

--- a/component/poll/poll.go
+++ b/component/poll/poll.go
@@ -1,0 +1,26 @@
+package io
+
+import (
+	"runtime"
+	"time"
+
+	monotonicclock "go.wasmcloud.dev/component/gen/wasi/clocks/monotonic-clock"
+	"go.wasmcloud.dev/component/gen/wasi/http/types"
+)
+
+// PollWithBackoff is a utility function that polls a given Pollable object
+// until it is ready, using an exponential backoff strategy starting at 1ms
+// and capping at 5 seconds. It uses a wasi:clocks/monotonic-clock pollable
+// to backoff and yield the thread to the Go runtime scheduler.
+func PollWithBackoff(pollable types.Pollable) {
+	backoffDuration := 1 * time.Millisecond
+	for !pollable.Ready() {
+		runtime.Gosched()
+		backoff := monotonicclock.SubscribeDuration(monotonicclock.Duration(backoffDuration))
+		backoff.Block()
+		backoffDuration *= 2
+		if backoffDuration > 5*time.Second {
+			backoffDuration = 5 * time.Second // Cap the backoff duration
+		}
+	}
+}

--- a/component/poll/poll.go
+++ b/component/poll/poll.go
@@ -8,11 +8,11 @@ import (
 	"go.wasmcloud.dev/component/gen/wasi/http/types"
 )
 
-// PollWithBackoff is a utility function that polls a given Pollable object
+// Resolve is a utility function that polls a given Pollable object
 // until it is ready, using an exponential backoff strategy starting at 1ms
 // and capping at 5 seconds. It uses a wasi:clocks/monotonic-clock pollable
 // to backoff and yield the thread to the Go runtime scheduler.
-func PollWithBackoff(pollable types.Pollable) {
+func Resolve(pollable types.Pollable) {
 	backoffDuration := 1 * time.Millisecond
 	for !pollable.Ready() {
 		runtime.Gosched()


### PR DESCRIPTION
Signed-off-by: Brooks Townsend <brooks@cosmonic.com>

## Feature or Problem
This PR resolves an issue where the polling of a future incoming HTTP response would hotloop on the pollable checking and runtime yielding. In order to do this, I used an exponential backoff with `wasi:clocks/monotonic-clock.subscribe-duration`, which creates a pollable that can be blocked on.

I'm not quite sure if this is the correct solution, but it does work. My hypothesis is that inbetween yielding to the go scheduler and checking the pollable there needs to be some amount of time and work driven forward which a hot loop prevents, but by blocking using a pollable rather than a hot loop it doesn't affect the wasmtime runtime. Given that this fixes the issue, I think my hypothesis is correct, but open to discussion of course.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
componentsdk v0.0.7

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
Before adding this change my concurrent HTTP requests would block, after they work
