### PR TITLE
ci: add /v2 to vanity

### DIFF
--- a/docs/runtime-operator/v2/index.html
+++ b/docs/runtime-operator/v2/index.html
@@ -1,0 +1,8 @@
+<html>
+  <head>
+    <meta
+      name="go-import"
+      content="go.wasmcloud.dev/runtime-operator git https://github.com/wasmCloud/wasmCloud runtime-operator"
+    />
+  </head>
+</html>


### PR DESCRIPTION
This won't impact current releases, but allows us to align everything to a v2 major version.